### PR TITLE
Add basic JIRA release progress app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# JIRA_Leadtime
+# JIRA Leadtime
+
+This repository contains a small Flask application that displays the
+progress for each JIRA release (version). Progress is determined using
+the following rules:
+
+- Issues in **DONE** count as 100% complete.
+- Issues in **INPROGRESS** (or "IN PROGRESS") count as 50% complete.
+- Issues in **TODO** count as 0% complete.
+
+For each release, the overall progress is calculated as:
+
+```
+progress = (100 * number_of_done_issues +
+            50 * number_of_inprogress_issues) /
+           (100 * total_number_of_issues)
+```
+
+For example, if a release has three issues, two in `INPROGRESS` and one
+in `TODO`, progress will be `(50*2 + 0) / 300 = 0.33` (33%).
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Provide JIRA connection information via environment variables:
+
+- `JIRA_BASE_URL` – base URL to your JIRA instance (e.g.
+  `https://your-domain.atlassian.net`)
+- `JIRA_EMAIL` – your JIRA account email
+- `JIRA_API_TOKEN` – API token for authentication
+- `JIRA_PROJECT_KEY` – project key to query
+
+3. Run the application:
+
+```bash
+python app.py
+```
+
+Then open `http://localhost:5000/` in your browser to see the progress
+for each release.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,75 @@
+import os
+import requests
+from flask import Flask, render_template_string
+
+app = Flask(__name__)
+
+JIRA_BASE_URL = os.getenv("JIRA_BASE_URL")
+JIRA_EMAIL = os.getenv("JIRA_EMAIL")
+JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN")
+JIRA_PROJECT_KEY = os.getenv("JIRA_PROJECT_KEY")
+
+auth = None
+if JIRA_EMAIL and JIRA_API_TOKEN:
+    auth = (JIRA_EMAIL, JIRA_API_TOKEN)
+
+
+def get_releases():
+    """Return a list of versions (releases) for the project."""
+    if not (JIRA_BASE_URL and JIRA_PROJECT_KEY):
+        return []
+    url = f"{JIRA_BASE_URL}/rest/api/3/project/{JIRA_PROJECT_KEY}/versions"
+    resp = requests.get(url, auth=auth)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_issues_for_release(version_name):
+    """Return issues associated with a release (version)."""
+    if not JIRA_BASE_URL:
+        return []
+    jql = f'fixVersion="{version_name}"'
+    url = f"{JIRA_BASE_URL}/rest/api/3/search"
+    params = {"jql": jql, "fields": "status"}
+    resp = requests.get(url, auth=auth, params=params)
+    resp.raise_for_status()
+    return resp.json().get("issues", [])
+
+
+def calculate_progress(issues):
+    """Calculate progress value 0..1 for a list of issues."""
+    total = len(issues)
+    if total == 0:
+        return 0
+    score = 0
+    for issue in issues:
+        status_name = issue["fields"]["status"]["name"].upper()
+        if status_name == "DONE":
+            score += 100
+        elif status_name in {"INPROGRESS", "IN PROGRESS"}:
+            score += 50
+    return score / (100 * total)
+
+
+@app.route("/")
+def index():
+    releases = get_releases()
+    data = []
+    for release in releases:
+        issues = get_issues_for_release(release["name"])
+        progress = calculate_progress(issues)
+        data.append({"name": release["name"], "progress": progress})
+    html = """
+    <h1>Release Progress</h1>
+    <table border="1">
+        <tr><th>Release</th><th>Progress</th></tr>
+        {% for r in data %}
+        <tr><td>{{ r.name }}</td><td>{{ '%0.2f' % (r.progress * 100) }}%</td></tr>
+        {% endfor %}
+    </table>
+    """
+    return render_template_string(html, data=data)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests


### PR DESCRIPTION
## Summary
- build a minimal Flask web app that fetches JIRA releases and issues
- compute progress per release using the DONE/INPROGRESS rule
- document the formula and setup instructions

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684919d246cc832f80ae31fc2c18121a